### PR TITLE
docs: Remove comments from VS Code JSON example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,15 @@ CLAUDE.md
 
 # cursor
 .cursor*
+
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json
+yarn.lock
+
+# PyInstaller
+# dist/ and build/ are already listed above
+*.spec

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ MCP Atlassian supports three authentication methods:
 > [!IMPORTANT]
 > Include `offline_access` in scope for persistent auth (e.g., `read:jira-work write:jira-work offline_access`)
 
-### 📦 2. Installation
+### 📦 2. Recommended Installation (Docker)
 
 MCP Atlassian is distributed as a Docker image. This is the recommended way to run the server, especially for IDE integration. Ensure you have Docker installed.
 
@@ -102,6 +102,48 @@ MCP Atlassian is designed to be used with AI assistants through IDE integration.
 > - **Linux**: `~/.config/Claude/claude_desktop_config.json`
 >
 > **For Cursor**: Open Settings → MCP → + Add new global MCP server
+
+### Usage with VS Code
+
+For quick installation of the `mcp-atlassian` server using the NPM package you've built, use one of the one-click install buttons below. This will configure the MCP VS Code extension to use `npx mcp-atlassian` to run the server.
+
+[![Install mcp-atlassian in VS Code](https://img.shields.io/badge/VS_Code-NPM-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=mcp-atlassian&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-atlassian%22%5D%7D)
+[![Install mcp-atlassian in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-NPM-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=mcp-atlassian&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-atlassian%22%5D%7D&quality=insiders)
+
+These buttons provide a basic setup. For passing credentials and other configurations (e.g., specific Jira/Confluence instances), refer to the manual installation example below and customize it by adding an `env` block with your environment variables.
+
+For manual installation, add the following JSON block to your User Settings (JSON) file in VS Code. You can do this by pressing `Ctrl + Shift + P` and typing `Preferences: Open User Settings (JSON)`.
+
+Optionally, you can add it to a file called `.vscode/mcp.json` in your workspace. This will allow you to share the configuration with others.
+
+> Note that the `mcp` key is not needed in the `.vscode/mcp.json` file.
+
+The example below shows a configuration using API Token authentication (recommended for Atlassian Cloud). You'll need to replace the placeholder values with your actual URLs, email, and API tokens.
+
+To use other authentication methods (like Personal Access Tokens for Server/Data Center or OAuth for Cloud), or to configure additional settings (like SSL verification, tool filters, content filters), you will need to add other environment variables to the `env` block. Please refer to the main [Authentication Setup](#-1-authentication-setup) section and the [`.env.example`](https://github.com/sooperset/mcp-atlassian/blob/main/.env.example) file for a comprehensive list of all available environment variables and their explanations. Copy the relevant variables from `.env.example` into the `env` block above and fill in your details.
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "mcp-atlassian": {
+        "command": "npx",
+        "args": ["-y", "mcp-atlassian"],
+        "env": {
+          "JIRA_URL": "YOUR_JIRA_INSTANCE_URL",
+          "CONFLUENCE_URL": "YOUR_CONFLUENCE_INSTANCE_URL",
+          "JIRA_USERNAME": "YOUR_ATLASSIAN_EMAIL_FOR_JIRA",
+          "JIRA_API_TOKEN": "YOUR_JIRA_API_TOKEN",
+          "CONFLUENCE_USERNAME": "YOUR_ATLASSIAN_EMAIL_FOR_CONFLUENCE",
+          "CONFLUENCE_API_TOKEN": "YOUR_CONFLUENCE_API_TOKEN",
+          "READ_ONLY_MODE": "false",
+          "MCP_VERBOSE": "true"
+        }
+      }
+    }
+  }
+}
+```
 
 ### ⚙️ Configuration Methods
 
@@ -655,3 +697,46 @@ We use pre-commit hooks for code quality and follow semantic versioning for rele
 ## License
 
 Licensed under MIT - see [LICENSE](LICENSE) file. This is not an official Atlassian product.
+
+## Installation as an npm Package
+
+This project can also be installed as an npm package, allowing you to use it from Node.js environments.
+
+### Prerequisites
+
+- Node.js and npm: Make sure you have Node.js and npm installed. You can download them from [https://nodejs.org/](https://nodejs.org/).
+- Python: A Python interpreter (version 3.10 or higher, as specified in `pyproject.toml`) must be available in your system's PATH. The npm install script will use `pip` to install Python dependencies.
+
+### Installation
+
+To install the package, run the following command in your project:
+
+```bash
+npm install <path-to-this-package-directory-or-git-url>
+```
+
+Or, if you are installing it globally (not recommended for most use cases):
+
+```bash
+npm install -g <path-to-this-package-directory-or-git-url>
+```
+
+The installation process will:
+1. Install PyInstaller and other Python dependencies.
+2. Package the Python application into a standalone executable using PyInstaller.
+
+### Usage
+
+Once installed, you can use the command-line interface provided by the package:
+
+```bash
+mcp-atlassian [arguments]
+```
+
+For example, to see the help message (assuming the Python application has a help option):
+
+```bash
+mcp-atlassian --help
+```
+
+The `mcp-atlassian` command will execute the underlying Python application.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+const path = require('path');
+
+// Determine the correct path to the executable based on the OS
+const executableName = 'mcp-atlassian' + (process.platform === 'win32' ? '.exe' : '');
+// Adjust the path to where PyInstaller places the executable (e.g., dist folder)
+const executablePath = path.join(__dirname, 'dist', executableName);
+
+const child = spawn(executablePath, process.argv.slice(2), {
+  stdio: 'inherit' // Pipe stdin, stdout, and stderr to the child process
+});
+
+child.on('error', (err) => {
+  console.error('Failed to start subprocess.', err);
+});
+
+child.on('exit', (code, signal) => {
+  if (code !== null) {
+    process.exitCode = code;
+  } else if (signal !== null) {
+    console.log(`Subprocess exited with signal ${signal}`);
+    process.exit(1); // Exit with an error code if killed by a signal
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "mcp-atlassian",
+  "version": "0.1.0",
+  "description": "MCP Atlassian integration",
+  "main": "index.js",
+  "bin": {
+    "mcp-atlassian": "./index.js"
+  },
+  "scripts": {
+    "install": "pip install pyinstaller && pyinstaller --name mcp-atlassian --onefile --console src/mcp_atlassian/servers/main.py",
+    "start": "node index.js"
+  },
+  "keywords": [
+    "mcp",
+    "atlassian",
+    "jira",
+    "confluence"
+  ],
+  "author": "sooperset <soomiles.dev@gmail.com>",
+  "license": "MIT"
+}


### PR DESCRIPTION
This commit updates the "Usage with VS Code" section in README.md. The example JSON configuration for `npx` has been modified to remove all embedded comments. The `env` block now primarily shows placeholders for the recommended API Token authentication method and a few common optional variables.

The accompanying text has been revised to clearly state that the example is for API Token auth and to explicitly direct you to the main "Authentication Setup" section and the `.env.example` file for a comprehensive list of all available environment variables, instructing you to copy relevant variables from there for other authentication methods (PAT, OAuth) or additional settings (SSL, filters).

<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

-
-
-

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [ ] Manual checks performed: `[briefly describe]`

## Checklist

- [ ] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).
