### PR TITLE
chore: Prepare package for npm publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,57 @@
+# Git / Version Control
+.git/
+.gitignore
+
+# Development Environment
+.devcontainer/
+.vscode/
+*.code-workspace
+
+# Python specific
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.python-version
+.venv/
+venv/
+env/
+*.egg-info/
+# dist/ and build/ are where PyInstaller creates the executable,
+# but this happens on the user's machine, not part of the published package.
+# However, if they exist locally during `npm publish --dry-run` or `npm publish`,
+# they might get packaged if not ignored. Best to ignore them.
+dist/
+build/
+*.spec
+pyproject.toml
+uv.lock
+poetry.lock
+Pipfile
+Pipfile.lock
+requirements.txt # If src/ is packaged, deps are in pyproject.toml, handled by pip in install script
+
+# Node specific (npm install creates node_modules, but it shouldn't be published)
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json # We have package.json, but lock files are usually not published
+
+# Project specific dev files / sensitive files
+.env
+.env.*
+*.env
+# .env.example is useful for users, but maybe not in the package itself if README covers setup.
+# For now, let's exclude it from the package to keep it lean.
+.env.example
+scripts/
+tests/
+examples/ # If you add examples later
+
+# OS specific
+.DS_Store
+Thumbs.db
+
+# Smithery specific (if this file is for local dev tooling only)
+smithery.yaml

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "mcp-atlassian",
+  "name": "@jophinzhu/mcp-atlassian",
   "version": "0.1.0",
-  "description": "MCP Atlassian integration",
+  "description": "MCP Atlassian integration: A Model Context Protocol server for Jira and Confluence.",
   "main": "index.js",
   "bin": {
     "mcp-atlassian": "./index.js"
@@ -10,12 +10,30 @@
     "install": "pip install pyinstaller && pyinstaller --name mcp-atlassian --onefile --console src/mcp_atlassian/servers/main.py",
     "start": "node index.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jophinzhu/mcp-atlassian.git"
+  },
   "keywords": [
     "mcp",
+    "model-context-protocol",
     "atlassian",
     "jira",
-    "confluence"
+    "confluence",
+    "ai",
+    "llm",
+    "automation"
   ],
-  "author": "sooperset <soomiles.dev@gmail.com>",
-  "license": "MIT"
+  "author": "Jophin Zhu <jophinzhu@outlook.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jophinzhu/mcp-atlassian/issues"
+  },
+  "homepage": "https://github.com/jophinzhu/mcp-atlassian#readme",
+  "files": [
+    "index.js",
+    "src/",
+    "README.md",
+    "LICENSE"
+  ]
 }


### PR DESCRIPTION
This commit updates `package.json` and adds an `.npmignore` file to prepare the `@jophinzhu/mcp-atlassian` package for publishing to npm.

Changes to `package.json`:
- Set package name to `@jophinzhu/mcp-atlassian`.
- Set version to `0.1.0`.
- Updated author to "Jophin Zhu <jophinzhu@outlook.com>".
- Added `repository`, `bugs`, and `homepage` fields pointing to the GitHub repository `https://github.com/jophinzhu/mcp-atlassian`.
- Expanded `keywords` for better discoverability.
- Added a `files` array to specify explicitly which files and directories are essential for the package (`index.js`, `src/`, `README.md`, `LICENSE`).

New `.npmignore` file:
- Added to exclude development-specific files, build artifacts not intended for the package, OS-specific files, and other non-essential items to ensure the published package is lean and clean.

<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

-
-
-

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [ ] Manual checks performed: `[briefly describe]`

## Checklist

- [ ] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).
